### PR TITLE
Add rustfmt and clippy to CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Check Formatting
         run: cargo fmt --all --check
       - name: Check Clippy
-        run: cargo clippy --deny warnings
+        run: cargo clippy -- --deny warnings

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: short
 
 jobs:
   build:
@@ -19,3 +23,16 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+  rustfmt:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Check Formatting
+        run: cargo fmt --all --check
+      - name: Check Clippy
+        run: cargo clippy --deny warnings

--- a/src/solves.rs
+++ b/src/solves.rs
@@ -20,9 +20,9 @@ pub fn get_data(year: u32, day: u32) -> Result<String, Box<dyn Error>> {
             .expect("Couldn't get session key to request data from. Add it to /data/session.txt");
         let data = request_data(year, day, session)?;
 
-        let _ = write_cache(year, day, &data).or_else(|e| {
+        let _ = write_cache(year, day, &data).map_err(|e| {
             println!("Couldn't write to cache!");
-            Err(e)
+            e
         });
 
         Ok(data)
@@ -30,7 +30,7 @@ pub fn get_data(year: u32, day: u32) -> Result<String, Box<dyn Error>> {
 }
 
 fn get_session() -> Result<String, io::Error> {
-    let mut file = File::open(format!("data/session.txt"))?;
+    let mut file = File::open("data/session.txt")?;
     let mut data = String::new();
 
     file.read_to_string(&mut data)?;
@@ -51,7 +51,7 @@ fn write_cache(year: u32, day: u32, data: &String) -> Result<(), Box<dyn Error>>
     create_dir_all(format!("data/cache/{year}"))?;
 
     let mut file = File::create(format!("data/cache/{year}/day{day}.txt"))?;
-    file.write(data.as_bytes())?;
+    file.write_all(data.as_bytes())?;
 
     Ok(())
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -156,7 +156,7 @@ fn day_menu(idx: usize, day: &AdventOfCodeDay, year: u32) {
                     run_solve(day.part2, year, (idx + 1) as u32);
                 }
 
-                println!("");
+                println!();
                 println!("{}", "[-1] - Go back".red());
 
                 loop {
@@ -170,7 +170,7 @@ fn day_menu(idx: usize, day: &AdventOfCodeDay, year: u32) {
                 new_menu();
                 run_solve(day.part1, year, (idx + 1) as u32);
 
-                println!("");
+                println!();
                 println!("{}", "[-1] - Go back".red());
 
                 loop {
@@ -184,7 +184,7 @@ fn day_menu(idx: usize, day: &AdventOfCodeDay, year: u32) {
                 new_menu();
                 run_solve(day.part2, year, (idx + 1) as u32);
 
-                println!("");
+                println!();
                 println!("{}", "[-1] - Go back".red());
 
                 loop {


### PR DESCRIPTION
Now we'll get format warnings on top of the usual test failures. Should improve code quality in the long run.