### PR TITLE
Skip installing rust dependencies on cache hit

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,11 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache Dependencies
+        id: rust-cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: cache-${{ hashFiles('**/Cargo.lock') }}
           cache-on-failure: true
       - name: Install Rust
+        if: ${{ !steps.rust-cache.outputs.cache-hit }}
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy


### PR DESCRIPTION
Should make cache much more stable and lead to consistent skips on installing dependencies for rustfmt / clippy.